### PR TITLE
Introduce NavigationSplitView, bump minimum deployment target to macOS13

### DIFF
--- a/Nimander.xcodeproj/project.pbxproj
+++ b/Nimander.xcodeproj/project.pbxproj
@@ -575,7 +575,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codecentric.Nimander;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -599,7 +599,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.2;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.codecentric.Nimander;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/Nimander/Scenes/App/Views/NimanderApp.swift
+++ b/Nimander/Scenes/App/Views/NimanderApp.swift
@@ -8,23 +8,15 @@
 import SwiftUI
 import BookmarkClient
 
-@available(macOS 12.0, *)
 @main
 struct NimanderApp: App {
     @StateObject private var viewModel: BookmarkViewModel = .production
+    @State private var visibility: NavigationSplitViewVisibility = .all
     @Environment(\.dismiss) var dismiss
 
     var body: some Scene {
         WindowGroup {
-                NavigationView {
-                    BookmarkSidebar()
-                    if let folder = viewModel.selectedFolder.wrappedValue {
-                        BookmarkListView(bookmarks: viewModel.folders[folder, default: []])
-                    }
-                    if let bookmark = viewModel.selectedBookmark.wrappedValue {
-                        BookmarkView(bookmark: bookmark)
-                    }
-                }
+            splitView
                 .sheet(isPresented: viewModel.requestAuthorization,
                        onDismiss: { dismiss() },
                        content: RequestAuthorizationDialog.init)
@@ -35,5 +27,20 @@ struct NimanderApp: App {
         .commands {
             SidebarCommands()
         }
+    }
+
+    private var splitView: some View {
+        NavigationSplitView(columnVisibility: $visibility) {
+            BookmarkSidebar()
+        } content: {
+            if let folder = viewModel.selectedFolder.wrappedValue {
+                BookmarkListView(bookmarks: viewModel.folders[folder, default: []])
+            }
+        } detail: {
+            if let bookmark = viewModel.selectedBookmark.wrappedValue {
+                BookmarkView(bookmark: bookmark)
+            }
+        }
+
     }
 }

--- a/Nimander/Scenes/Bookmarks/Models/Browser.swift
+++ b/Nimander/Scenes/Bookmarks/Models/Browser.swift
@@ -5,6 +5,14 @@
 //  Created by Nikola Stojanovic on 8.1.22..
 //
 
+struct Folder: Hashable {
+    var name: String
+    var icon: String
+
+    static let google = Self(name: "Google", icon: "g.circle")
+    static let safari = Self(name: "Safari", icon: "safari")
+}
+
 enum Browser: String, CaseIterable, Identifiable {
     case safari, google
 

--- a/Nimander/Scenes/Bookmarks/Views/BookmarkSidebar.swift
+++ b/Nimander/Scenes/Bookmarks/Views/BookmarkSidebar.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 import BookmarkClient
 
-@available(macOS 12.0, *)
 struct BookmarkSidebar: View {
     @EnvironmentObject var viewModel: BookmarkViewModel
 

--- a/Nimander/Scenes/Bookmarks/Views/BookmarkView.swift
+++ b/Nimander/Scenes/Bookmarks/Views/BookmarkView.swift
@@ -16,8 +16,6 @@ struct BookmarkView: View {
     var body: some View {
         if let url = bookmark.url {
             BookmarkWebView(url: url)
-        } else {
-            EmptyView()
         }
     }
 }


### PR DESCRIPTION
This PR is a breaking PR, as introducing NavigationSplitView causes the app to crash when selecting a bookmark. This issue will be addressed in a follow up PR, for a stable version of the app please checkout the last stable tag, git checkout v0.0.1 .